### PR TITLE
Add script to generate distribution tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.db
+/dist

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,113 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1708410168,
+        "narHash": "sha256-98kCv2PbKfqt+oyyXHqdXPRRGjW+QEy9eBzNtRyCRHs=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "846fc5ddb810c36411de6587384bef86c2db5127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1698420672,
+        "narHash": "sha256-/TdeHMPRjjdJub7p7+w55vyABrsJlt5QkznPYy55vKA=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "aeb58d5e8faead8980a807c840232697982d47b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1708296515,
+        "narHash": "sha256-FyF489fYNAUy7b6dkYV6rGPyzp+4tThhr80KNAaF/yY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b98a4e1746acceb92c509bc496ef3d0e5ad8d4aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1708407374,
+        "narHash": "sha256-EECzarm+uqnNDCwaGg/ppXCO11qibZ1iigORShkkDf0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f33dd27a47ebdf11dc8a5eb05e7c8fbdaf89e73f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1708296515,
+        "narHash": "sha256-FyF489fYNAUy7b6dkYV6rGPyzp+4tThhr80KNAaF/yY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b98a4e1746acceb92c509bc496ef3d0e5ad8d4aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_3"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708361159,
+        "narHash": "sha256-HAZ/pEN0TVFoGMbITliYXbMLPaSy/X+WKY/y6K8iTr0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "2223b4fa71e543ac6dd1abd4770a69fab8dbdec1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  description = "Notification service";
+  inputs = {
+    fenix.url = "github:nix-community/fenix";
+    naersk.url = "github:nix-community/naersk";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs, naersk, fenix }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      formatter = nixpkgs.lib.genAttrs supportedSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages."${system}";
+        in
+        pkgs.nixpkgs-fmt
+      );
+
+      packages = nixpkgs.lib.genAttrs supportedSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages."${system}";
+          buildNotifiers = (arch:
+            let
+              crossSystem = "${arch}-unknown-linux-musl";
+              pkgsCross = import nixpkgs ({
+                system = system;
+                crossSystem.config = crossSystem;
+              });
+              rustToolchain = with fenix.packages.${system};
+                combine [
+                  stable.rustc
+                  stable.cargo
+                  targets.${crossSystem}.stable.rust-std
+                ];
+
+              naersk' = pkgs.callPackage naersk {
+                cargo = rustToolchain;
+                rustc = rustToolchain;
+              };
+            in
+            naersk'.buildPackage rec {
+              pname = "notifiers";
+              src = ./.;
+              nativeBuildInputs = [
+                pkgs.pkg-config
+              ];
+
+              TARGET_CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
+              CARGO_BUILD_RUSTFLAGS = [ "-C" "linker=${TARGET_CC}" ];
+
+              OPENSSL_STATIC = 1;
+              OPENSSL_LIB_DIR = "${pkgsCross.pkgsStatic.openssl.out}/lib";
+              OPENSSL_INCLUDE_DIR = "${pkgsCross.pkgsStatic.openssl.dev}/include";
+              CARGO_BUILD_TARGET = crossSystem;
+            }
+          );
+        in
+        rec {
+          default = x86_64;
+          x86_64 = buildNotifiers "x86_64";
+          aarch64 = buildNotifiers "aarch64";
+        }
+      );
+    };
+}

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Build static Linux binary using musl
+set -euo pipefail
+
+VERSION=0.1.0
+TMP="$(mktemp -d)"
+DESTDIR="$TMP/notifiers-$VERSION-linux-x86_64"
+mkdir -p "$DESTDIR"
+nix build .#x86_64
+cp result/bin/notifiers "$DESTDIR"
+pushd "$TMP"
+tar czf "notifiers-$VERSION-linux-x86_64.tar.gz" "notifiers-$VERSION-linux-x86_64"
+popd
+mkdir -p dist
+mv "$TMP/notifiers-$VERSION-linux-x86_64.tar.gz" "dist/notifiers-$VERSION-linux-x86_64.tar.gz"
+rm -fr "$TMP"


### PR DESCRIPTION
We have no tagged releases yet, can do a release shortly after and then modify the script to use `git describe`.
So far tested that the script generates a tarball:
```
$ tar tf dist/notifiers-0.1.0-linux-x86_64.tar.gz 
notifiers-0.1.0-linux-x86_64/
notifiers-0.1.0-linux-x86_64/notifiers
```