### PR TITLE
Remove `--sandbox` option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,6 @@ use notifiers::{notifier, server};
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// If set, this will use the sandbox servers, instead of the production ones.
-    #[structopt(short, long)]
-    sandbox: bool,
     /// Path to the certificate file PKS12.
     #[structopt(long, parse(from_os_str))]
     certificate_file: PathBuf,
@@ -38,11 +35,6 @@ async fn main() -> Result<()> {
     femme::start();
 
     let opt = Opt::from_args();
-    let endpoint = if opt.sandbox {
-        a2::Endpoint::Sandbox
-    } else {
-        a2::Endpoint::Production
-    };
     let certificate = std::fs::File::open(&opt.certificate_file).context("invalid certificate")?;
 
     let state = server::State::new(&opt.db)?;
@@ -55,7 +47,6 @@ async fn main() -> Result<()> {
     let notif = async_std::task::spawn(async move {
         notifier::start(
             state.db(),
-            endpoint,
             certificate,
             &opt.password,
             opt.topic.as_deref(),

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -8,7 +8,6 @@ use log::*;
 
 pub async fn start(
     db: &sled::Db,
-    endpoint: Endpoint,
     mut certificate: std::fs::File,
     password: &str,
     topic: Option<&str>,
@@ -18,6 +17,7 @@ pub async fn start(
         "Waking up devices every {}",
         humantime::format_duration(interval)
     );
+    let endpoint = Endpoint::Production;
     let client = Client::certificate(&mut certificate, password, endpoint)?;
 
     // first wakeup on startup


### PR DESCRIPTION
If we reintroduce sandbox notifications,
we can connect to both endpoints
in the same process and distinguish
by tokens whether we should use production on sandbox client. This way core and email servers don't need to know which `notifiers` server should be used.