### PR TITLE
fix: do not try to notify FCM tokens registered for periodic notifications

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -75,7 +75,7 @@ async fn register_device(
     Ok(())
 }
 
-enum NotificationToken {
+pub(crate) enum NotificationToken {
     /// Android App.
     Fcm {
         /// Package name such as `chat.delta`.


### PR DESCRIPTION
Periodic notifications should only be used for APNS tokens. If some client erroneously registers an FCM token
via `/register` endpoint, we should not send it to Apple.