### PR TITLE
fix(metrics): output the number of Web Push instead of UBPorts notifications

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -81,7 +81,7 @@ impl Metrics {
         registry.register(
             "webpush_notifications",
             "Number of web push notifications",
-            ubports_notifications_total.clone(),
+            webpush_notifications_total.clone(),
         );
 
         let debounced_notifications_total = Counter::default();


### PR DESCRIPTION
This is a follow-up for #53 