### PR TITLE
refactor: Use non-poisoning sync primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1698,11 +1698,10 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -1829,6 +1828,7 @@ dependencies = [
  "femme",
  "humantime",
  "log",
+ "parking_lot 0.12.5",
  "pgp",
  "prometheus-client",
  "rand",
@@ -2055,12 +2055,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.9",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -2079,15 +2079,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2326,7 +2326,7 @@ checksum = "c1ca959da22a332509f2a73ae9e5f23f9dcfc31fd3a54d71f159495bd5909baa"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "prometheus-client-derive-encode",
 ]
 
@@ -2408,6 +2408,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.4.0",
 ]
 
 [[package]]
@@ -3186,7 +3195,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.7",
@@ -3638,6 +3647,12 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ structopt = "0.3.15"
 tokio = { version = "1.39.2", features = ["full"] }
 web-push-native = "0.4.0"
 yup-oauth2 = "9.0.0"
+parking_lot = "0.12.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/debouncer.rs
+++ b/src/debouncer.rs
@@ -11,9 +11,9 @@
 //! can decrypt them, notification gateway needs
 //! to debounce notifications to the same token.
 
+use parking_lot::RwLock;
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashSet};
-use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
 #[derive(Default)]
@@ -82,14 +82,14 @@ impl Debouncer {
     /// and should not be notified again.
     #[cfg(test)]
     pub(crate) fn is_debounced(&self, now: Instant, token: &String) -> bool {
-        let mut state = self.state.write().unwrap();
+        let mut state = self.state.write();
         state.is_debounced(now, token)
     }
 
     /// Returns true if notification should be sent,
     /// false if the token is currently debounced.
     pub(crate) fn notify(&self, now: Instant, token: String) -> bool {
-        self.state.write().unwrap().notify(now, token)
+        self.state.write().notify(now, token)
     }
 
     /// Returns number of currently debounced notification tokens.
@@ -98,7 +98,7 @@ impl Debouncer {
     ///
     /// This function does not remove expired tokens.
     pub(crate) fn count(&self) -> usize {
-        self.state.read().unwrap().count()
+        self.state.read().count()
     }
 }
 

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,7 +1,7 @@
+use parking_lot::Mutex;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::path::Path;
-use std::sync::Mutex;
 use std::time::SystemTime;
 
 use anyhow::Result;
@@ -43,7 +43,7 @@ impl Schedule {
     /// to update latest notification time.
     pub fn insert_token(&self, token: &str, now: u64) -> Result<()> {
         self.db.insert(token.as_bytes(), &u64::to_be_bytes(now))?;
-        let mut heap = self.heap.lock().unwrap();
+        let mut heap = self.heap.lock();
         heap.push((Reverse(now), token.to_owned()));
         Ok(())
     }
@@ -70,7 +70,7 @@ impl Schedule {
     }
 
     pub fn pop(&self) -> Result<Option<(u64, String)>> {
-        let mut heap = self.heap.lock().unwrap();
+        let mut heap = self.heap.lock();
         loop {
             let Some((timestamp, token)) = heap.pop() else {
                 return Ok(None);
@@ -90,7 +90,7 @@ impl Schedule {
 
     /// Returns the number of tokens in the schedule.
     pub fn token_count(&self) -> usize {
-        let heap = self.heap.lock().unwrap();
+        let heap = self.heap.lock();
         heap.len()
     }
 }


### PR DESCRIPTION
This gets rid of few unwraps.