### PR TITLE
fix: Unsubscribe APNS tokens on DeviceTokenNotForTopic error

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -459,7 +459,10 @@ async fn notify_apns(
                 .inc();
 
             let bad_token = if let Some(err) = res.error {
-                err.reason == ErrorReason::BadDeviceToken
+                matches!(
+                    err.reason,
+                    ErrorReason::BadDeviceToken | ErrorReason::DeviceTokenNotForTopic
+                )
             } else {
                 false
             };


### PR DESCRIPTION
We are currently flooding APNS with requests that
result in unrecoverable 400 DeviceTokenNotForTopic.

Most of these request are with the same token.