### PR TITLE
fix: send high priority fcm messages

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -341,7 +341,7 @@ async fn notify_fcm(
 
     let url = "https://fcm.googleapis.com/v1/projects/delta-chat-fcm/messages:send";
     let body =
-        format!("{{\"message\":{{\"token\":\"{token}\",\"data\":{{\"level\": \"awesome\"}} }} }}");
+        format!("{{\"message\":{{\"token\":\"{token}\",\"data\":{{\"level\":\"awesome\"}},\"android\":{{\"priority\":\"high\"}} }} }}");
     let res = client
         .post(url)
         .body(body.clone())


### PR DESCRIPTION
I noticed that gplay push notifications are not reliable when the device has been locked for some minutes. My suspicion is this happens because of "Doze". I tried to reproduce the issue with a fairphone 3 by [setting force-idle](https://developer.android.com/training/monitoring-device-state/doze-standby#testing_doze), which makes notifications stop working.

As far as I understand the [docs](https://firebase.google.com/docs/cloud-messaging/android-message-priority) about fcm data messages the default priority is "normal" and thus does not wake up the device from "Doze", so I created this PR.

I would need help testing this to check if it has the desired effect.